### PR TITLE
Rename Project

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,8 @@
 E-mail addresses listed here are not intended for support.
 
-py-esp32-ulp authors
---------------------
-py-esp32-ulp is written and maintained by various contributors:
+micropython-esp32-ulp authors
+-----------------------------
+micropython-esp32-ulp is written and maintained by various contributors:
 
 - Thomas Waldmann <tw@waldmann-edv.de>
 - Wilko Nienhaus <wilko.nienhaus@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2018-2021 by the py-esp32-ulp authors, see AUTHORS file
+Copyright 2018-2021 by the micropython-esp32-ulp authors, see AUTHORS file
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2018-2021 by the micropython-esp32-ulp authors, see AUTHORS file
+Copyright 2018-2022 by the micropython-esp32-ulp authors, see AUTHORS file
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -7,11 +7,11 @@
 
 .. end-badges
 
-============
-py-esp32-ulp
-============
+=====================
+micropython-esp32-ulp
+=====================
 
-py-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
+micropython-esp32-ulp is an assembler toolchain for the ESP32 ULP (Ultra Low-Power)
 Co-Processor, written in MicroPython.
 
 It can translate small assembly language programs to a loadable/executable
@@ -43,10 +43,10 @@ To get going run the following directly on the ESP32:
 
 .. code-block:: python
 
-   # Step 1: Install py-esp32-ulp
+   # Step 1: Install micropython-esp32-ulp
    # IMPORTANT: Ensure the ESP32 is connected to a network with internet connectivity.
    import upip
-   upip.install('micropython-py-esp32-ulp')
+   upip.install('micropython-esp32-ulp')
 
    # Step 2: Run an example
    # First, upload examples/counter.py to the ESP32.
@@ -66,7 +66,7 @@ Requirements
 
 The minimum supported version of MicroPython is v1.12.
 
-An ESP32 is required to run the ULP machine code binary produced by py-esp32-ulp
+An ESP32 is required to run the ULP machine code binary produced by micropython-esp32-ulp
 (the ESP32-S2 will not work as it is not binary compatible with the ESP32).
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-py-esp32-ulp Documentation
-==========================
+micropython-esp32-ulp Documentation
+===================================
 
 .. contents:: Table of Contents
 
@@ -19,7 +19,7 @@ On the ESP32, install using upip:
 
    # ensure the ESP32 is connected to a network with internet connectivity
    import upip
-   upip.install('micropython-py-esp32-ulp')
+   upip.install('micropython-esp32-ulp')
 
 On a PC, simply ``git clone`` this repo.
 
@@ -36,7 +36,7 @@ data between the ULP and the main CPU.
 
 Run the ``counter.py`` example:
 
-1. Install py-esp32-ulp onto the ESP32 as shown above
+1. Install micropython-esp32-ulp onto the ESP32 as shown above
 2. Upload the `examples/counter.py </examples/counter.py>`_ file to the ESP32
 3. Run with ``import counter``
 
@@ -54,8 +54,8 @@ follows:
 
 .. code-block:: shell
 
-   git clone https://github.com/ThomasWaldmann/py-esp32-ulp.git
-   cd py-esp32-ulp
+   git clone https://github.com/micropython/micropython-esp32-ulp.git
+   cd micropython-esp32-ulp
    micropython -m esp32_ulp path/to/code.S  # this results in path/to/code.ulp
 
 
@@ -153,7 +153,7 @@ Testing
 There are unit tests and also compatibility tests that check whether the binary
 output is identical with what binutils-esp32ulp produces.
 
-py-esp32-ulp has been tested on the Unix port of MicroPython and on real ESP32
+micropython-esp32-ulp has been tested on the Unix port of MicroPython and on real ESP32
 devices with the chip type ESP32D0WDQ6 (revision 1) without SPIRAM.
 
 Consult the Github Actions `workflow definition file </.github/workflows/run_tests.yaml>`_

--- a/docs/preprocess.rst
+++ b/docs/preprocess.rst
@@ -2,7 +2,7 @@
 Preprocessor
 =====================
 
-py-esp32-ulp contains a small preprocessor, which aims to fulfill one goal:
+micropython-esp32-ulp contains a small preprocessor, which aims to fulfill one goal:
 facilitate assembling of ULP code from Espressif and other open-source
 projects to loadable/executable machine code without modification.
 
@@ -46,7 +46,7 @@ With the preprocessor, simply pass the source code via the preprocessor first:
 Using a "Defines Database"
 --------------------------
 
-Because the py-esp32-ulp assembler was built for running on the ESP32
+Because the micropython-esp32-ulp assembler was built for running on the ESP32
 microcontroller with limited RAM, the preprocessor aims to work there too.
 
 To handle large number of defined constants (such as the ``RTC_*`` constants from

--- a/setup.py
+++ b/setup.py
@@ -17,18 +17,18 @@ def long_desc_from_readme():
 
 
 setup(
-    name="micropython-py-esp32-ulp",
+    name="micropython-esp32-ulp",
     use_scm_version={
         'local_scheme': 'no-local-version',
     },
     description="Assembler toolchain for the ESP32 ULP co-processor, written in MicroPython",
     long_description=long_desc_from_readme(),
     long_description_content_type='text/x-rst',
-    url="https://github.com/ThomasWaldmann/py-esp32-ulp",
+    url="https://github.com/micropython/micropython-esp32-ulp",
     license="MIT",
-    author="py-esp32-ulp authors",
+    author="micropython-esp32-ulp authors",
     author_email="tw@waldmann-edv.de",
-    maintainer="py-esp32-ulp authors",
+    maintainer="micropython-esp32-ulp authors",
     maintainer_email="tw@waldmann-edv.de",
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import re
-import sdist_upip
 from setuptools import setup
+import sdist_upip
 
 
 def long_desc_from_readme():

--- a/tests/01_compat_tests.sh
+++ b/tests/01_compat_tests.sh
@@ -14,7 +14,7 @@ for src_file in $(ls -1 compat/*.S); do
     src_name="${src_file%.S}"
     
     echo "Testing $src_file"
-    echo -e "\tBuilding using py-esp32-ulp"
+    echo -e "\tBuilding using micropython-esp32-ulp"
     ulp_file="${src_name}.ulp"
     log_file="${src_name}.log"
     micropython -m esp32_ulp $src_file 1>$log_file   # generates $ulp_file
@@ -34,9 +34,9 @@ for src_file in $(ls -1 compat/*.S); do
         echo -e "\tBuild outputs differ!"
         echo ""
         echo "Compatibility test failed for $src_file"
-        echo "py-esp32-ulp log:"
+        echo "micropython-esp32-ulp log:"
         cat $log_file
-        echo "py-esp32-ulp output:"
+        echo "micropython-esp32-ulp output:"
         xxd $ulp_file
         echo "binutils output:"
         xxd $bin_file

--- a/tests/02_compat_rtc_tests.sh
+++ b/tests/02_compat_rtc_tests.sh
@@ -123,11 +123,11 @@ for src_file in ulptool/src/ulp_examples/*/*.s binutils-esp32ulp/gas/testsuite/g
         # switch to the patched file instead of original one
         src_file="${src_dir}/${test_name}.tmp"
         src_name="${src_file%.tmp}"
-        ulp_file="${src_name}.tmp.ulp"  # when extension is not .s, py-esp32-ulp doesn't remove original extension
+        ulp_file="${src_name}.tmp.ulp"  # when extension is not .s, micropython-esp32-ulp doesn't remove original extension
     fi
     # END: work around known issues with binutils-esp32ulp
 
-    echo -e "\tBuilding using py-esp32-ulp"
+    echo -e "\tBuilding using micropython-esp32-ulp"
     log_file="${src_name}.log"
     micropython -m esp32_ulp $src_file 1>$log_file   # generates $ulp_file
 
@@ -148,9 +148,9 @@ for src_file in ulptool/src/ulp_examples/*/*.s binutils-esp32ulp/gas/testsuite/g
         echo -e "\tBuild outputs differ!"
         echo ""
         echo "Compatibility test failed for $src_file"
-        echo "py-esp32-ulp log:"
+        echo "micropython-esp32-ulp log:"
         cat $log_file
-        echo "py-esp32-ulp output:"
+        echo "micropython-esp32-ulp output:"
         xxd $ulp_file
         echo "binutils output:"
         xxd $bin_file

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -1,6 +1,6 @@
   .text
   .set const, 3
-  .global const  # exporting symbol is required for binutils, not important for py-esp32-ulp
+  .global const  # exporting symbol is required for binutils, not important for micropython-esp32-ulp
 
 entry:
   nop


### PR DESCRIPTION
This PR changes the project name from **py-esp32-ulp** to **micropython-esp32-ulp**, under the assumption that we change the repo name to `micropython-esp32-ulp` too.

See #61 for the background/motivation of this PR.

Somewhat unrelated, it also updates the Copyright date (to avoid a PR for just that small change).